### PR TITLE
Unsigned integer (uint8) cannot be negative

### DIFF
--- a/src/SampleDecoder.cpp
+++ b/src/SampleDecoder.cpp
@@ -161,7 +161,7 @@ SampleEncoding getEncoding(uint8_t sampleType) {
             };
 
         default:
-            return {-1, {}};
+            return {0, {}};
     }
 }
 


### PR DESCRIPTION
While compilation using the Arduino IDE (1.8.X and below) works fine, when using the Arduino-CLI (like one might in a GitLab pipeline), an error is thrown because of this.