### PR TITLE
Fix invalid return type for sample decoder

### DIFF
--- a/src/SampleDecoder.cpp
+++ b/src/SampleDecoder.cpp
@@ -161,7 +161,7 @@ SampleEncoding getEncoding(uint8_t sampleType) {
             };
 
         default:
-            return {-1, {}};
+            return {0, {}};
     }
 }
 


### PR DESCRIPTION
struct SampleEncoding has type unit and therefore can't return -1 for minFrameSize.
Having a default of 0 for min frame size therefore makes more sense. In case of unknown frames it will not decode any samples instead of failing to decode.